### PR TITLE
Change multiline regex pattern and the limits

### DIFF
--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureReader.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureReader.java
@@ -50,10 +50,10 @@ public abstract class FailureReader {
 
     private static final Logger logger = Logger.getLogger(FailureReader.class.getName());
 
-    private static final long TIMEOUT_FILE = 10000;
-    private static final long TIMEOUT_LINE = 1000;
+    private static final long TIMEOUT_FILE = 20000;
+    private static final long TIMEOUT_LINE = 5000;
     private static final long SLEEPTIME = 200;
-    private static final int SCAN_HORIZON = 10000;
+    private static final int SCAN_HORIZON = 1000000;
 
     /** The indication we are looking for. */
     protected Indication indication;
@@ -166,6 +166,7 @@ public abstract class FailureReader {
             long startTime = System.currentTimeMillis();
             while (scanner.hasNext()) {
                 try {
+                    // findWithinHorizon() ignores the delimiter
                     matchingString = scanner.findWithinHorizon(pattern, SCAN_HORIZON);
                     if (matchingString != null) {
                         found = true;

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/indication/MultilineBuildLogIndication.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/indication/MultilineBuildLogIndication.java
@@ -66,7 +66,8 @@ public class MultilineBuildLogIndication extends BuildLogIndication {
     @Override
     public Pattern getPattern() {
         if (compiled == null) {
-            compiled = Pattern.compile("(?m)(?s)^[\\r\\n]*?" + getUserProvidedExpression() + "[^\\r\\n]*?$");
+            // compiled = Pattern.compile("(?m)(?s)^[^\\r\\n]*?" + getUserProvidedExpression() + "[^\\r\\n]*?$");
+            compiled = Pattern.compile("(?m)" + getUserProvidedExpression());
         }
         return compiled;
     }


### PR DESCRIPTION
The multiline regex pattern "modification" is wrong, but instead of fixing it,
this change basically removes it and only prepends "(?m)".

Also the hard-coded limits were a bit conservative.
